### PR TITLE
Fix: Make rotation methods chainable, add tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -760,22 +760,24 @@ Victor.prototype.rotate = function (angle) {
 
 	this.x = nx;
 	this.y = ny;
+
+	return this;
 };
 
 Victor.prototype.rotateDeg = function (angle) {
 	angle = degrees2radian(angle);
-	this.rotate(angle);
+	return this.rotate(angle);
 };
 
 Victor.prototype.rotateBy = function (rotation) {
 	var angle = this.angle() + rotation;
 
-	this.rotate(angle);
+	return this.rotate(angle);
 };
 
 Victor.prototype.rotateByDeg = function (rotation) {
 	rotation = degrees2radian(rotation);
-	this.rotateBy(rotation);
+	return this.rotateBy(rotation);
 };
 
 /**

--- a/test/victor.js
+++ b/test/victor.js
@@ -542,6 +542,77 @@ describe('chainable instance methods', function () {
 		});
 	});
 
+	describe('#rotate()', function () {
+		var vec, ret;
+
+		before(function () {
+			vec = new Victor(100, 100);
+			ret = vec.rotate(90 * Math.PI / 180);
+		});
+
+		it('should be chainable', function () {
+			expect(ret).to.equal(vec);
+		});
+
+		it('should set the rotation angle', function () {
+			expect(vec).to.have.property('x', -100);
+			expect(vec).to.have.property('y', 100);
+		});
+	});
+
+	describe('#rotateDeg()', function () {
+		var vec, ret;
+
+		before(function () {
+			vec = new Victor(100, 100);
+			ret = vec.rotateDeg(90);
+		});
+
+		it('should be chainable', function () {
+			expect(ret).to.equal(vec);
+		});
+
+		it('should set the rotation angle in degrees', function () {
+			expect(vec).to.have.property('x', -100);
+			expect(vec).to.have.property('y', 100);
+		});
+	});
+
+	describe('#rotateBy()', function () {
+		var vec, ret;
+
+		before(function () {
+			vec = new Victor(100, 100);
+			ret = vec.rotateBy(45 * Math.PI / 180);
+		});
+
+		it('should be chainable', function () {
+			expect(ret).to.equal(vec);
+		});
+
+		it('should rotate by the given angle', function () {
+			expect(vec).to.have.property('x', -100);
+			expect(vec).to.have.property('y', 100);
+		});
+	});
+
+	describe('#rotateByDeg()', function () {
+		var vec, ret;
+
+		before(function () {
+			vec = new Victor(100, 100);
+			ret = vec.rotateByDeg(45);
+		});
+
+		it('should be chainable', function () {
+			expect(ret).to.equal(vec);
+		});
+
+		it('should rotate by the given angle in degrees', function () {
+			expect(vec).to.have.property('x', -100);
+			expect(vec).to.have.property('y', 100);
+		});
+	});
 });
 
 describe('regular instance methods', function () {


### PR DESCRIPTION
The documentation on the website claims that the rotation methods are chainable, this pull request makes that true. :)

I also added tests for both the chainability and the rotation functionality.
