### PR TITLE
Enhance documentation of rotate* commands.

### DIFF
--- a/index.html
+++ b/index.html
@@ -954,7 +954,7 @@
 					<div class="row doc-row">
 						<div class="col-md-6 doc-text">
 							<h4><a name="rotate"></a><tt>.rotate(angle)</tt> <span class="label-chainable">chainable</span></h4>
-							<p>Rotates the vector to a certain angle.</p>
+							<p>Rotates the vector to a certain angle, in radians CCW from +X axis.</p>
 							<dl class="method-docs">
 								<dt>Params</dt>
 								<dd>
@@ -996,7 +996,7 @@
 					<div class="row doc-row">
 						<div class="col-md-6 doc-text">
 							<h4><a name="rotateby"></a><tt>.rotateBy(rotation)</tt> <span class="label-chainable">chainable</span></h4>
-							<p>Rotates the vector by a rotation angle.</p>
+							<p>Rotates the vector by a rotation angle, given in radians CCW from +X axis.</p>
 							<dl class="method-docs">
 								<dt>Params</dt>
 								<dd>


### PR DESCRIPTION
This commit adds a note that the reference frame for the rotate commands
is CCW from the +X axis.

This resolves #6 .
