### PR TITLE
 * rotateTo added

### DIFF
--- a/index.js
+++ b/index.js
@@ -791,6 +791,15 @@ Victor.prototype.rotateDeg = function (angle) {
 	return this.rotate(angle);
 };
 
+Victor.prototype.rotateTo = function(rotation) {
+	return this.rotate(rotation-this.angle());
+};
+
+Victor.prototype.rotateToDeg = function(rotation) {
+	rotation = degrees2radian(rotation);
+	return this.rotateTo(rotation);
+};
+
 Victor.prototype.rotateBy = function (rotation) {
 	var angle = this.angle() + rotation;
 

--- a/test/victor.js
+++ b/test/victor.js
@@ -1,9 +1,7 @@
-var chai = require('chai');
-var chaiStats = require('chai-stats');
+var expect = require('chai').expect;
 var Victor = require('../index');
 
-chai.use(chaiStats);
-var expect = chai.expect;
+var EPSILON = 0.0001;
 
 describe('static methods', function () {
 
@@ -547,7 +545,7 @@ describe('chainable instance methods', function () {
 	});
 	
 	describe('#horizontalAngle()', function(){
-		var PRECISION = 6;
+		
 		var angleX,angleY;
 		before(function(){
 			angleX = new Victor(100,0).horizontalAngle();
@@ -556,15 +554,15 @@ describe('chainable instance methods', function () {
 		});
 		
 		it('should x directed vector to 0°', function(){
-			expect(angleX).almost.equal(0,PRECISION);
+			expect(Math.abs(angleX - 0)).to.lte(0,EPSILON);
 		});
 		
 		it('should y directed vector to 90°', function(){
-			expect(angleY).almost.equal(Math.PI/2,PRECISION);
+			expect(Math.abs(angleY - Math.PI/2)).to.lte(EPSILON);
 		});
 		
 		it('should negative x directed vector to 180°', function(){
-			expect(angleXPi).almost.equal(Math.PI,PRECISION);
+			expect(Math.abs(angleXPi - Math.PI)).to.lte(EPSILON);
 		});
 	});
 
@@ -583,7 +581,7 @@ describe('chainable instance methods', function () {
 		it('should rotate the vector by certain degrees', function () {
 			expect(vec).to.have.property('x', -100);
 			expect(vec).to.have.property('y', 100);
-			expect(vec.horizontalAngle()).almost.equal(135 * Math.PI / 180,6);
+			expect(Math.abs(vec.horizontalAngle() - 135 * Math.PI / 180)).to.lte(EPSILON);
 		});
 	});
 	
@@ -608,7 +606,7 @@ describe('chainable instance methods', function () {
 	
 	
 	describe('#rotateTo()', function(){
-		var vecX,vecY, retX, retY, EPSILON= 0;
+		var vecX,vecY, retX, retY;
 		
 		
 		before(function(){
@@ -635,7 +633,6 @@ describe('chainable instance methods', function () {
 	});
 	
 	describe('#rotateToDeg()', function(){
-		var PRECISION = 6;
 		var vec,ret;
 		before(function(){
 			vec = new Victor(100,0);
@@ -649,7 +646,7 @@ describe('chainable instance methods', function () {
 		});
 		
 		it('should rotate any Vector to a given angle', function(){
-			expect(vec.angleDeg()).almost.equal(120,PRECISION);
+			expect(Math.abs(vec.angleDeg()-120)).to.lte(EPSILON);
 		
 		});
 		

--- a/test/victor.js
+++ b/test/victor.js
@@ -1,5 +1,9 @@
-var expect = require('chai').expect;
+var chai = require('chai');
+var chaiStats = require('chai-stats');
 var Victor = require('../index');
+
+chai.use(chaiStats);
+var expect = chai.expect;
 
 describe('static methods', function () {
 
@@ -541,6 +545,28 @@ describe('chainable instance methods', function () {
 			expect(vec).to.have.property('y', 0);
 		});
 	});
+	
+	describe('#horizontalAngle()', function(){
+		var PRECISION = 6;
+		var angleX,angleY;
+		before(function(){
+			angleX = new Victor(100,0).horizontalAngle();
+			angleY = new Victor(0,100).horizontalAngle();
+			angleXPi = new Victor(-100,0).horizontalAngle();
+		});
+		
+		it('should x directed vector to 0°', function(){
+			expect(angleX).almost.equal(0,PRECISION);
+		});
+		
+		it('should y directed vector to 90°', function(){
+			expect(angleY).almost.equal(Math.PI/2,PRECISION);
+		});
+		
+		it('should negative x directed vector to 180°', function(){
+			expect(angleXPi).almost.equal(Math.PI,PRECISION);
+		});
+	});
 
 	describe('#rotate()', function () {
 		var vec, ret;
@@ -554,11 +580,13 @@ describe('chainable instance methods', function () {
 			expect(ret).to.equal(vec);
 		});
 
-		it('should set the rotation angle', function () {
+		it('should rotate the vector by certain degrees', function () {
 			expect(vec).to.have.property('x', -100);
 			expect(vec).to.have.property('y', 100);
+			expect(vec.horizontalAngle()).almost.equal(135 * Math.PI / 180,6);
 		});
 	});
+	
 
 	describe('#rotateDeg()', function () {
 		var vec, ret;
@@ -576,6 +604,60 @@ describe('chainable instance methods', function () {
 			expect(vec).to.have.property('x', -100);
 			expect(vec).to.have.property('y', 100);
 		});
+	});
+	
+	
+	describe('#rotateTo()', function(){
+		var vecX,vecY, retX, retY, EPSILON= 0;
+		
+		
+		before(function(){
+			vecX = new Victor(100,0);
+			vecY = new Victor(0,100);
+			retX = vecX.rotateTo(120 * Math.PI / 180);
+			retY = vecY.rotateTo(120 * Math.PI / 180);
+		});
+		
+		it('should be chainable', function(){
+			expect(retX).to.equal(vecX);
+		});
+		
+		it('should rotate any Vector to a given angle', function(){
+			expect(vecX.angle()).to.equal(120 * Math.PI /180);
+			expect(vecY.angle()).to.equal(120 * Math.PI /180);
+		});
+		
+		it('should keep the length', function(){
+			expect(retX.length()).to.equal(100);
+			expect(retY.length()).to.equal(100);
+		});
+		
+	});
+	
+	describe('#rotateToDeg()', function(){
+		var PRECISION = 6;
+		var vec,ret;
+		before(function(){
+			vec = new Victor(100,0);
+			
+			ret = vec.rotateToDeg(120);
+			
+		});
+		
+		it('should be chainable', function(){
+			expect(ret).to.equal(vec);
+		});
+		
+		it('should rotate any Vector to a given angle', function(){
+			expect(vec.angleDeg()).almost.equal(120,PRECISION);
+		
+		});
+		
+		it('should keep the length', function(){
+			expect(ret.length()).to.equal(100);
+			
+		});
+		
 	});
 
 	describe('#rotateBy()', function () {


### PR DESCRIPTION
The #rotate\[Deg\]() and #rotateBy\[Deg\]() seems to be mixed up.

The function rotate() currently rotates the vector _by_ the given angle not _to_ the given angle. As it is documented. So the implementation does a relative move instead of an absolute independent from the current angle of the vector.
Example: new Victor(0,1) is at 90° from X+ axis. So new Victor(0,1).rotateDeg(180) results in a vector at 270° not at 180°.
(Rotate only moves a vector to (and also by) the given angle if this specific vector point in the direction of the X+ axis.) 

The function rotateBy() seems to make no sense. It adds the current angle to the given rotation value and rotates it by this sum. The unit test seems to be wrong.

I created this pull request to provide a new rotateTo() method which can be used to set the absolute angle of a vector.
The rotate() method can be used to move vector relative to its current position And could further be renamed to  rotateBy(). 
The current rotateBy() method could be remove from my point of view. But may be I have overseen something.