### PR TITLE
Divide by scalar value instead of new vector

### DIFF
--- a/index.js
+++ b/index.js
@@ -652,7 +652,7 @@ Victor.prototype.normalize = function () {
 		this.x = 1;
 		this.y = 0;
 	} else {
-		this.divide(Victor(length, length));
+		this.divideScalar(length);
 	}
 	return this;
 };


### PR DESCRIPTION
This prevents the creation of a new temporary Victor object in the normalize function and should make things very slightly faster